### PR TITLE
Change the fs-htcondor jobs universe to local

### DIFF
--- a/templates/job_working_dir.job.j2
+++ b/templates/job_working_dir.job.j2
@@ -1,8 +1,7 @@
-Universe = vanilla
+Universe = local
 Executable = {{ fsm_maintenance_dir }}/job_working_dir.sh
 Log = {{ fsm_maintenance_dir }}/maintenance_job_working_dir.log
 Output = {{ fsm_maintenance_dir }}/maintenance_job_working_dir.out
 Error = {{ fsm_maintenance_dir }}/maintenance_job_working_dir.err
 Request_cpus = 1
-Requirements = GalaxyGroup == "maintenance"
 Queue

--- a/templates/temporary_dirs.job.j2
+++ b/templates/temporary_dirs.job.j2
@@ -1,8 +1,7 @@
-Universe = vanilla
+Universe = local
 Executable = {{ fsm_maintenance_dir }}/temporary_dirs.sh
 Log = {{ fsm_maintenance_dir }}/maintenance_temporary_dirs.$(process).log
 Output = {{ fsm_maintenance_dir }}/maintenance_temporary_dirs.$(process).out
 Error = {{ fsm_maintenance_dir }}/maintenance_temporary_dirs.$(process).err
 request_cpus = 1
-Requirements = GalaxyGroup == "maintenance"
 Queue

--- a/templates/uploads.job.j2
+++ b/templates/uploads.job.j2
@@ -1,8 +1,7 @@
-Universe = vanilla
+Universe = local
 Executable = {{ fsm_maintenance_dir }}/uploads.sh
 Log = {{ fsm_maintenance_dir }}/maintenance_uploads.log
 Output = {{ fsm_maintenance_dir }}/maintenance_uploads.out
 Error = {{ fsm_maintenance_dir }}/maintenance_uploads.err
 Request_cpus = 1
-Requirements = GalaxyGroup == "maintenance"
 Queue


### PR DESCRIPTION
This will allow the jobs to run from where it was submitted because the [old maintenance VM](https://github.com/usegalaxy-eu/vgcn-infrastructure/pull/180) where these jobs were run in the past will be removed and so the `GalaxyGroup == "maintenance"` will not be available any more. These jobs should be deployed and run on the new maintenance VM dedicated for such tasks.

universes from `condor_submit` man page:
```
universe = <vanilla | standard | scheduler | local | grid | java| vm | parallel | docker>
                 Specifies which HTCondor universe to use when running this job. The HTCondor universe specifies an HTCondor execution environment.

                 The vanilla universe is the default (except where the configuration variable DEFAULT_UNIVERSE
                   defines  it otherwise), and is an execution environment for jobs which do not use HTCondor's mechanisms for taking checkpoints; these are ones that have not been linked with the HTCon‐
                 dor libraries. Use the vanilla universe to submit shell scripts to HTCondor.

                 The standard universe tells HTCondor that this job has been re-linked via condor_compile with the HTCondor libraries and therefore supports taking checkpoints and remote system calls.

                 The scheduler universe is for a job that is to run on the machine where the job is submitted. This universe is intended for a job that acts as a metascheduler and will not be preempted.

                 The local universe is for a job that is to run on the machine where the job is submitted. This universe runs the job immediately and will not preempt the job.

                 The grid universe forwards the job to an external job management system. Further specification of the grid universe is done with the grid_resource command.

                 The java universe is for programs written to the Java Virtual Machine.

                 The vm universe facilitates the execution of a virtual machine.

                 The parallel universe is for parallel jobs (e.g. MPI) that require multiple machines in order to run.

                 The docker universe runs a docker container as an HTCondor job.
```