### PR TITLE
improve cron logic

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,27 +40,7 @@ fsm_scripts:
     paths: []
     time: "{{ fsm_intervals.long }}"
 
-fsm_cron_tasks:
-  docker:
-    enable: False
-    name: "Docker clean up"
-    minute: 30
-    hour: 2
-    dom: "*"
-    month: "*"
-    dow: "*"
-    job: "docker system prune -f > /dev/null"
-    user: "{{ fsm_galaxy_user.username }}"
-  gxadmin:
-    enable: False
-    name: "Gxadmin Galaxy clean up"
-    minute: 0
-    hour: "*/6"
-    dom: "*"
-    month: "*"
-    dow: "*"
-    job: "/usr/bin/gxadmin galaxy cleanup 60"
-    user: "{{ fsm_galaxy_user.username }}"
+fsm_cron_tasks: {}
 
 fsm_htcondor_enable: False
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,27 @@ fsm_scripts:
     paths: []
     time: "{{ fsm_intervals.long }}"
 
-fsm_cron_tasks: {}
+fsm_cron_tasks:
+  docker:
+    enable: False
+    name: "Docker clean up"
+    minute: 30
+    hour: 2
+    dom: "*"
+    month: "*"
+    dow: "*"
+    job: "docker system prune -f > /dev/null"
+    user: "{{ fsm_galaxy_user.username }}"
+  gxadmin:
+    enable: False
+    name: "Gxadmin Galaxy clean up"
+    minute: 0
+    hour: "*/6"
+    dom: "*"
+    month: "*"
+    dow: "*"
+    job: "/usr/bin/gxadmin galaxy cleanup 60"
+    user: "{{ fsm_galaxy_user.username }}"
 
 fsm_htcondor_enable: False
 

--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -1,15 +1,13 @@
 ---
 - name: Add maintenance tasks to cron
   ansible.builtin.cron:
-    name: "{{ item.name }}"
-    minute: "{{ item.minute }}"
-    hour: "{{ item.hour }}"
-    dom: "{{ item.dom }}"
-    month: "{{ item.month }}"
-    dow: "{{ item.dow }}"
-    job: "{{ item.job }}"
-    user: "{{ item.user }}"
-  loop:
-    - "{{ fsm_cron_tasks.docker }}"
-    - "{{ fsm_cron_tasks.gxadmin }}"
-  when: "item.enable | bool"
+    name: "{{ item.value.name }}"
+    minute: "{{ item.value.minute }}"
+    hour: "{{ item.value.hour }}"
+    dom: "{{ item.value.dom }}"
+    month: "{{ item.value.month }}"
+    dow: "{{ item.value.dow }}"
+    job: "{{ item.value.job }}"
+    user: "{{ item.value.user }}"
+  loop: "{{ fsm_cron_tasks | dict2items }}"
+  when: "item.value.enable | bool"


### PR DESCRIPTION
The variable `fsm_cron_tasks` is in the [group variables](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/7aa8df7a677319b04b6f01b23ad4861dbc472b07/group_vars/maintenance.yml#L154) of maintenance. 
So we don't need to change two times the same variable and make sure is in the loop, I improved it to iterate over the dictionary instead. 