### PR TITLE
Use `ANSIBLE_GALAXY_API_KEY` to publish role

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,4 +29,4 @@ jobs:
         run: pip3 install ansible-core
 
       - name: Trigger a new import on Galaxy.
-        run: ansible-galaxy role import --api-key ${{ secrets.ANSIBLE_GALAXY_API_KEY_V2 }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2) --branch main
+        run: ansible-galaxy role import --api-key ${{ secrets.ANSIBLE_GALAXY_API_KEY }} $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2) --branch main


### PR DESCRIPTION
Publish role to Ansible Galaxy using `ANSIBLE_GALAXY_API_KEY` rather than `ANSIBLE_GALAXY_API_KEY_V2`.

The latter was probably a quick fix by someone from our team and is now broken, likely because a new API key was generated by that person.